### PR TITLE
fix: add missing cast from jsonb to rruleset

### DIFF
--- a/src/casts/casts.sql
+++ b/src/casts/casts.sql
@@ -11,7 +11,10 @@ CREATE CAST (TEXT AS _rrule.RRULESET)
 CREATE CAST (jsonb AS _rrule.RRULE)
   WITH FUNCTION _rrule.jsonb_to_rrule(jsonb)
   AS IMPLICIT;
-
+  
+CREATE CAST (jsonb AS _rrule.RRULESET)
+  WITH FUNCTION _rrule.jsonb_to_rruleset(jsonb)
+  AS IMPLICIT;
 
 CREATE CAST (_rrule.RRULE AS jsonb)
   WITH FUNCTION _rrule.rrule_to_jsonb(_rrule.RRULE)


### PR DESCRIPTION
Whenever I was trying to convert jsonb to rruleset, it threw an error saying: jsonb cannot be cast to rruleset.

I see that you made a function for casting but maybe forgot to add it in the casts file.

This PR adds the missing cast.